### PR TITLE
商品情報編集機能

### DIFF
--- a/app/controllers/item_purchases_controller.rb
+++ b/app/controllers/item_purchases_controller.rb
@@ -1,7 +1,7 @@
 class ItemPurchasesController < ApplicationController
   before_action :authenticate_user!
-  before_action :move_to_index , only: :index
-  before_action :item_data , only: [:index, :create]
+  before_action :move_to_index, only: :index
+  before_action :item_data, only: [:index, :create]
 
   def index
     @purchase_form = PurchaseForm.new
@@ -19,21 +19,22 @@ class ItemPurchasesController < ApplicationController
   end
 
   private
+
   def item_purchase_params
-    params.require(:purchase_form).permit(:postal_code, :prefecture_id, :city, :house_number, :building_name, :phone_number).merge(token: params[:token],user_id: current_user.id, item_id: params[:item_id])
+    params.require(:purchase_form).permit(:postal_code, :prefecture_id, :city, :house_number, :building_name, :phone_number).merge(token: params[:token], user_id: current_user.id, item_id: params[:item_id])
   end
 
   def pay_item
-    Payjp.api_key = ENV["PAYJP_SECRET_KEY"]  # 自身のPAY.JPテスト秘密鍵
+    Payjp.api_key = ENV['PAYJP_SECRET_KEY']  # 自身のPAY.JPテスト秘密鍵
     Payjp::Charge.create(
-      amount: Item.find(params[:item_id]).price,  # 商品の値段
-      card: params[:token],    # カードトークン
+      amount: Item.find(params[:item_id]).price, # 商品の値段
+      card: params[:token], # カードトークン
       currency: 'jpy'                # 通貨の種類（日本円）
     )
   end
 
   def move_to_index
-    item = Item.find(params[:item_id]) 
+    item = Item.find(params[:item_id])
     if item.user_id == current_user.id
       redirect_to items_path
     elsif item.item_purchase.present?
@@ -44,5 +45,4 @@ class ItemPurchasesController < ApplicationController
   def item_data
     @item = Item.find(params[:item_id])
   end
-
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
   before_action :move_to_index, only: [:edit, :update]
+  before_action :item_data, only: [:show, :edit, :update]
 
   def index
     @item = Item.includes(:user).order('created_at DESC')
@@ -20,15 +21,12 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @item = Item.find(params[:id])
   end
 
   def edit
-    @item = Item.find(params[:id])
   end
 
   def update
-    @item = Item.find(params[:id])
     if @item.update(item_params)
       redirect_to items_path
     else
@@ -49,5 +47,9 @@ class ItemsController < ApplicationController
     elsif item.item_purchase.present?
       redirect_to items_path
     end
+  end
+
+  def item_data
+    @item = Item.find(params[:id])
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,8 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
-  before_action :move_to_index, only: [:edit, :update]
   before_action :item_data, only: [:show, :edit, :update]
+  before_action :move_to_index, only: [:edit, :update]
+  
 
   def index
     @item = Item.includes(:user).order('created_at DESC')
@@ -41,10 +42,9 @@ class ItemsController < ApplicationController
   end
 
   def move_to_index
-    item = Item.find(params[:id])
-    if item.user_id != current_user.id
+    if @item.user_id != current_user.id
       redirect_to items_path
-    elsif item.item_purchase.present?
+    elsif @item.item_purchase.present?
       redirect_to items_path
     end
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -22,6 +22,19 @@ class ItemsController < ApplicationController
     @item = Item.find(params[:id])
   end
 
+  def edit
+    @item = Item.new
+  end
+
+  def update
+    @item = Item.new(item_params)
+    if @item.save
+      redirect_to items_path
+    else
+      render '/items/new'
+    end
+  end
+
   private
 
   def item_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
+  before_action :move_to_index, only: [:edit, :update]
 
   def index
     @item = Item.includes(:user).order('created_at DESC')
@@ -14,7 +15,7 @@ class ItemsController < ApplicationController
     if @item.save
       redirect_to items_path
     else
-      render '/items/new'
+      render new_item_path
     end
   end
 
@@ -23,15 +24,15 @@ class ItemsController < ApplicationController
   end
 
   def edit
-    @item = Item.new
+    @item = Item.find(params[:id])
   end
 
   def update
-    @item = Item.new(item_params)
-    if @item.save
+    @item = Item.find(params[:id])
+    if @item.update(item_params)
       redirect_to items_path
     else
-      render '/items/new'
+      render :edit
     end
   end
 
@@ -39,5 +40,14 @@ class ItemsController < ApplicationController
 
   def item_params
     params.require(:item).permit(:name, :price, :introduction, :category_id, :condition_id, :delivery_fee_id, :prefecture_id, :send_time_id, :image).merge(user_id: current_user.id)
+  end
+
+  def move_to_index
+    item = Item.find(params[:id])
+    if item.user_id != current_user.id
+      redirect_to items_path
+    elsif item.item_purchase.present?
+      redirect_to items_path
+    end
   end
 end

--- a/app/models/purchase_form.rb
+++ b/app/models/purchase_form.rb
@@ -1,14 +1,14 @@
 class PurchaseForm
   include ActiveModel::Model
   attr_accessor :postal_code, :prefecture_id, :city, :house_number, :building_name, :phone_number, :token, :user_id, :item_id
- 
+
   with_options presence: true do
     validates :token
-    validates :postal_code, format: {with: /\A[0-9]{3}-[0-9]{4}\z/, message: "Input correctly"}
-    validates :prefecture_id, numericality: { other_than: 0, message: "Select"}
+    validates :postal_code, format: { with: /\A[0-9]{3}-[0-9]{4}\z/, message: 'Input correctly' }
+    validates :prefecture_id, numericality: { other_than: 0, message: 'Select' }
     validates :city
     validates :house_number
-    validates :phone_number, format: {with: /\A\d{1,11}/, message: "Input only number"}
+    validates :phone_number, format: { with: /\A\d{1,11}/, message: 'Input only number' }
     validates :user_id
     validates :item_id
   end

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -9,9 +9,7 @@ app/assets/stylesheets/items/new.css %>
     <h2 class="items-sell-title">商品の情報を入力</h2>
     <%= form_with(model: @item , local: true) do |f| %>
 
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
     <%= render 'shared/error_messages', model: f.object %>
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
 
     <%# 出品画像 %>
     <div class="img-upload">

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -3,14 +3,14 @@ app/assets/stylesheets/items/new.css %>
 
 <div class="items-sell-contents">
   <header class="items-sell-header">
-    <%= link_to image_tag('furima-logo-color.png' , size: '185x50'), "/" %>
+    <%= link_to image_tag(@item.image , size: '185x50'), "/" %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
+    <%= form_with(model: @item , local: true) do |f| %>
 
     <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%# render 'shared/error_messages', model: f.object %>
+    <%= render 'shared/error_messages', model: f.object %>
     <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
 
     <%# 出品画像 %>
@@ -23,7 +23,7 @@ app/assets/stylesheets/items/new.css %>
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :hoge, id:"item-image" %>
+        <%= f.file_field :image, id:"item-image" %>
       </div>
     </div>
     <%# /出品画像 %>
@@ -33,13 +33,13 @@ app/assets/stylesheets/items/new.css %>
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <%= f.text_area :name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <%= f.text_area :introduction, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
       </div>
     </div>
     <%# /商品名と商品説明 %>
@@ -52,12 +52,12 @@ app/assets/stylesheets/items/new.css %>
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select(:category_id, Category.all , :id, :name , {}, {class:"select-box", id:"item-category"}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select(:condition_id, Condition.all , :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -73,17 +73,17 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:delivery_fee_id, DeliveryFee.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:send_time_id, SendTime.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>
@@ -101,7 +101,7 @@ app/assets/stylesheets/items/new.css %>
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -28,7 +28,7 @@
     <%# 購入機能見実装のため、「販売済みの時に表示されない機能」は未実装 %>
     <% if user_signed_in? %>   
       <% if @item.user_id == current_user.id %>
-        <%= link_to '商品の編集', edit_item_path(:id), method: :get, class: "item-red-btn" %>
+        <%= link_to '商品の編集', edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
         <p class='or-text'>or</p>
         <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
       <% elsif @item.item_purchase.nil? %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -28,7 +28,7 @@
     <%# 購入機能見実装のため、「販売済みの時に表示されない機能」は未実装 %>
     <% if user_signed_in? %>   
       <% if @item.user_id == current_user.id %>
-        <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+        <%= link_to '商品の編集', edit_item_path(:id), method: :get, class: "item-red-btn" %>
         <p class='or-text'>or</p>
         <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
       <% elsif @item.item_purchase.nil? %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   root to:"items#index"
   devise_for :users
   
-  resources :items, only: [:index, :new, :create, :show] do
+  resources :items, only: [:index, :new, :create, :show, :edit, :update] do
     resources :item_purchases, only: [:index, :create]
   end
 

--- a/spec/factories/order_addresses.rb
+++ b/spec/factories/order_addresses.rb
@@ -1,5 +1,4 @@
 FactoryBot.define do
   factory :order_address do
-    
   end
 end

--- a/spec/factories/purchase_form.rb
+++ b/spec/factories/purchase_form.rb
@@ -1,16 +1,14 @@
 FactoryBot.define do
   factory :purchase_form do
+    postal_code { '123-4567' }
+    prefecture_id { 15 }
+    city { '横浜市' }
+    house_number { '東京1番地' }
+    building_name { 'なんとかbulding' }
+    phone_number { '00123456789' }
 
-    postal_code {"123-4567"}
-    prefecture_id {15}
-    city {"横浜市"}
-    house_number {"東京1番地"}
-    building_name {"なんとかbulding"}
-    phone_number {"00123456789"}
-
-    token {"0a0a0a"}
-    user_id {1}
-    item_id {2}
-
+    token { '0a0a0a' }
+    user_id { 1 }
+    item_id { 2 }
   end
 end

--- a/spec/models/item_purchase_spec.rb
+++ b/spec/models/item_purchase_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe ItemPurchase, type: :model do
       it 'prefectureが0だと登録できない' do
         @item_purchase.prefecture_id = 0
         @item_purchase.valid?
-        expect(@item_purchase.errors.full_messages).to include("Prefecture Select")
+        expect(@item_purchase.errors.full_messages).to include('Prefecture Select')
       end
       it 'cityが空だと登録できない' do
         @item_purchase.city = nil
@@ -34,9 +34,9 @@ RSpec.describe ItemPurchase, type: :model do
         expect(@item_purchase.errors.full_messages).to include("Phone number can't be blank")
       end
       it 'phone_numberが数字以外だと登録できない' do
-        @item_purchase.postal_code =  "一二三四五六七八九十零"
+        @item_purchase.postal_code = '一二三四五六七八九十零'
         @item_purchase.valid?
-        expect(@item_purchase.errors.full_messages).to include("Phone number Input only number")
+        expect(@item_purchase.errors.full_messages).to include('Phone number Input only number')
       end
     end
   end

--- a/spec/models/purchase_form_spec.rb
+++ b/spec/models/purchase_form_spec.rb
@@ -24,14 +24,14 @@ RSpec.describe PurchaseForm, type: :model do
         expect(@purchase_form.errors.full_messages).to include("Postal code can't be blank")
       end
       it 'postal_codeにハイフンが無いと登録できない' do
-        @purchase_form.postal_code = "1234567"
+        @purchase_form.postal_code = '1234567'
         @purchase_form.valid?
-        expect(@purchase_form.errors.full_messages).to include("Postal code Input correctly")
+        expect(@purchase_form.errors.full_messages).to include('Postal code Input correctly')
       end
       it 'prefectureが0だと登録できない' do
         @purchase_form.prefecture_id = 0
         @purchase_form.valid?
-        expect(@purchase_form.errors.full_messages).to include("Prefecture Select")
+        expect(@purchase_form.errors.full_messages).to include('Prefecture Select')
       end
       it 'cityが空だと登録できない' do
         @purchase_form.city = nil
@@ -44,9 +44,9 @@ RSpec.describe PurchaseForm, type: :model do
         expect(@purchase_form.errors.full_messages).to include("Phone number can't be blank")
       end
       it 'phone_numberが数字以外だと登録できない' do
-        @purchase_form.phone_number =  "一二三四五六七八九十零"
+        @purchase_form.phone_number = '一二三四五六七八九十零'
         @purchase_form.valid?
-        expect(@purchase_form.errors.full_messages).to include("Phone number Input only number")
+        expect(@purchase_form.errors.full_messages).to include('Phone number Input only number')
       end
       it 'user_idが空だと登録できない' do
         @purchase_form.user_id = nil

--- a/spec/requests/item_purchases_request_spec.rb
+++ b/spec/requests/item_purchases_request_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
 
-RSpec.describe "ItemPurchases", type: :request do
-
+RSpec.describe 'ItemPurchases', type: :request do
 end


### PR DESCRIPTION
# What
・商品の情報を編集機能を実装
・出品者のみ編集ページに遷移できるようにした。
・ログイン状態や出品者かどうか、販売済みかどうかで遷移先が変わるようにbefore_actionでフィルターをかけた。

# Why
・出品後に商品の情報を編集できるようにするため
・出品者以外が編集できてしまったり、販売済みの商品が編集されたりすることを防ぐため

# 機能GIF
エラーが表示される
https://gyazo.com/29d04fe8d215b0aef92ac7cf852d6854

情報を持って編集ページに遷移する
https://gyazo.com/41abbd45a04336fee531075cdb426648

出品者以外はURLを直接入力しても遷移できない
https://gyazo.com/92e285568babc74fa87cff6a49536a73

ご確認の程よろしくお願い致します。